### PR TITLE
Install Fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ node_js:
 - 6.4.0
 script:
 - npm test
+- npm run setup-selenium
 - npm run example &
 - npm run e2e
 deploy:

--- a/nightwatch.conf.js
+++ b/nightwatch.conf.js
@@ -1,9 +1,6 @@
-const fs = require('fs');
-const seleniumDownload = require('selenium-download');
-
 const BINPATH = './node_modules/nightwatch/bin/';
 
-const config = {
+module.exports = {
   src_folders: [
     'test/e2e', // Where you are storing your Nightwatch e2e/UAT tests
   ],
@@ -35,19 +32,3 @@ const config = {
     },
   },
 };
-
-/**
- * selenium-download does exactly what it's name suggests;
- * downloads (or updates) the version of Selenium (& chromedriver)
- * on your localhost where it will be used by Nightwatch.
- */
-fs.stat(`${BINPATH}selenium.jar`, (err, stat) => {
-  if (err || !stat || stat.size < 1) {
-    seleniumDownload.ensure(BINPATH, (error) => {
-      if (error) throw new Error(error);
-      console.log('✔ Selenium & Chromedriver downloaded to:', BINPATH);
-    });
-  }
-});
-
-module.exports = config;

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "build": "webpack -p --config webpack.config.js",
     "watch": "webpack --config webpack.config.js --watch",
     "example": "NODE_ENV=DEVELOPMENT webpack-dev-server --content-base example/ --config example/webpack.config.js --progress --colors",
-    "postinstall": "node nightwatch.conf.js",
     "prepublish": "npm run build"
   },
   "author": "Autodesk Bio/Nano",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "molecule-2d-for-react",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "2D molecule visualization using React and D3",
   "main": "dist/bundle.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
   "scripts": {
     "test": "karma start --single-run",
     "tdd": "karma start",
+    "setup-selenium": "node scripts/download_selenium.js",
     "e2e": "./node_modules/nightwatch/bin/nightwatch",
     "build": "webpack -p --config webpack.config.js",
     "watch": "webpack --config webpack.config.js --watch",

--- a/scripts/download_selenium.js
+++ b/scripts/download_selenium.js
@@ -1,0 +1,19 @@
+const fs = require('fs');
+const seleniumDownload = require('selenium-download');
+
+const BINPATH = './node_modules/nightwatch/bin/';
+
+/**
+ * selenium-download does exactly what it's name suggests;
+ * downloads (or updates) the version of Selenium (& chromedriver)
+ * on your localhost where it will be used by Nightwatch.
+ */
+fs.stat(`${BINPATH}selenium.jar`, (err, stat) => {
+  if (err || !stat || stat.size < 1) {
+    seleniumDownload.ensure(BINPATH, (error) => {
+      if (error) throw new Error(error);
+      console.log('✔ Selenium & Chromedriver downloaded to:', BINPATH);
+    });
+  }
+});
+


### PR DESCRIPTION
This package's postinstall script was causing `npm install` to fail on projects that used it.  The problem was our postinstall script to download selenium binaries, which is totally irrelevant to users and shouldn't be run on postinstall.

See this issue: https://github.com/Autodesk/notebook-molecular-visualization/issues/33